### PR TITLE
groovy.lang.GroovyRuntimeException: Conflicting module versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,26 +120,26 @@
             <artifactId>serenity-rest-assured</artifactId>
             <version>${serenity.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!--Excluding Groovy because of classpath issue-->
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-xml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>30.0-jre</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-            <version>3.0.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-xml</artifactId>
-            <version>3.0.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-json</artifactId>
-            <version>3.0.6</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
groovy.lang.GroovyRuntimeException: Conflicting module versions when trying to run test with restasssured. removed groovy dependency from pom because serenity-core and serenity-rest-assured bring that in. excluded it from one though because they come with different versions. not sure if later serenity versions fix that?